### PR TITLE
chore: fix monaco shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
   <link rel="stylesheet" href="./src/styles/reset.css" />
   <link rel="stylesheet" href="./src/styles/app.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.54.0/min/vs/editor/editor.main.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs/editor/editor.main.css" />
 </head>
 
 <body>
@@ -71,7 +71,7 @@
         "imports": {
           "@hirosystems/clarinet-sdk-browser": "https://esm.sh/@hirosystems/clarinet-sdk-browser@3.8.1",
           "@stacks/transactions": "https://esm.sh/@stacks/transactions@7.2.0",
-          "monaco-editor": "https://cdn.jsdelivr.net/npm/monaco-editor@0.54.0/+esm",
+          "monaco-editor": "https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/+esm",
           "monaco-editor-textmate": "https://esm.sh/monaco-editor-textmate@4.0.0",
           "monaco-textmate": "https://esm.sh/monaco-textmate@3.0.1",
           "onigasm": "https://esm.sh/onigasm@2.2.5"

--- a/index.html
+++ b/index.html
@@ -8,17 +8,6 @@
   <meta name="description" content="Run and test Clarity smart contracts in the browser with Clarinet" />
   <link rel="icon" href="/images/favicon.svg" />
 
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-D6SJVXJMFY"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-    gtag("config", "G-D6SJVXJMFY");
-  </script>
-
   <meta property="og:title" content="Clarity Playground" />
   <meta property="og:description" content="Run and test Clarity smart contracts in the browser with Clarinet" />
   <meta property="og:image" content="https://play.hiro.so/images/og-cp.jpg" />
@@ -26,7 +15,7 @@
 
   <link rel="stylesheet" href="./src/styles/reset.css" />
   <link rel="stylesheet" href="./src/styles/app.css" />
-  <link rel="stylesheet" href="https://esm.sh/monaco-editor@0.54.0/min/vs/editor/editor.main.css" />
+  <link rel="stylesheet" href="https://esm.sh/monaco-editor@0.52.0/min/vs/editor/editor.main.css" />
 </head>
 
 <body>
@@ -82,7 +71,7 @@
         "imports": {
           "@hirosystems/clarinet-sdk-browser": "https://esm.sh/@hirosystems/clarinet-sdk-browser@3.8.1",
           "@stacks/transactions": "https://esm.sh/@stacks/transactions@7.2.0",
-          "monaco-editor": "https://esm.sh/monaco-editor@0.54.0",
+          "monaco-editor": "https://esm.sh/monaco-editor@0.52.0",
           "monaco-editor-textmate": "https://esm.sh/monaco-editor-textmate@4.0.0",
           "monaco-textmate": "https://esm.sh/monaco-textmate@3.0.1",
           "onigasm": "https://esm.sh/onigasm@2.2.5"

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
   <link rel="stylesheet" href="./src/styles/reset.css" />
   <link rel="stylesheet" href="./src/styles/app.css" />
-  <link rel="stylesheet" href="https://esm.sh/monaco-editor@0.52.0/min/vs/editor/editor.main.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.54.0/min/vs/editor/editor.main.css" />
 </head>
 
 <body>
@@ -71,7 +71,7 @@
         "imports": {
           "@hirosystems/clarinet-sdk-browser": "https://esm.sh/@hirosystems/clarinet-sdk-browser@3.8.1",
           "@stacks/transactions": "https://esm.sh/@stacks/transactions@7.2.0",
-          "monaco-editor": "https://esm.sh/monaco-editor@0.52.0",
+          "monaco-editor": "https://cdn.jsdelivr.net/npm/monaco-editor@0.54.0/+esm",
           "monaco-editor-textmate": "https://esm.sh/monaco-editor-textmate@4.0.0",
           "monaco-textmate": "https://esm.sh/monaco-textmate@3.0.1",
           "onigasm": "https://esm.sh/onigasm@2.2.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@hirosystems/clarinet-sdk-browser": "3.8.1",
         "@stacks/transactions": "7.2.0",
-        "monaco-editor": "0.52.0",
+        "monaco-editor": "0.54.0",
         "monaco-editor-textmate": "4.0.0",
         "monaco-textmate": "3.0.1",
         "onigasm": "2.2.5",
@@ -802,8 +802,8 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
       "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
       "dev": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@hirosystems/clarinet-sdk-browser": "3.8.1",
         "@stacks/transactions": "7.2.0",
-        "monaco-editor": "0.54.0",
+        "monaco-editor": "0.52.0",
         "monaco-editor-textmate": "4.0.0",
         "monaco-textmate": "3.0.1",
         "onigasm": "2.2.5",
@@ -520,13 +520,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
-      "dev": true,
-      "license": "(MPL-2.0 OR Apache-2.0)"
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -715,19 +708,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -802,15 +782,11 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
-      "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
+      "integrity": "sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "3.1.7",
-        "marked": "14.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/monaco-editor-textmate": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@hirosystems/clarinet-sdk-browser": "3.8.1",
         "@stacks/transactions": "7.2.0",
-        "monaco-editor": "0.54.0",
+        "monaco-editor": "0.52.0",
         "monaco-editor-textmate": "4.0.0",
         "monaco-textmate": "3.0.1",
         "onigasm": "2.2.5",
@@ -802,8 +802,8 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.0.tgz",
       "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
       "dev": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@hirosystems/clarinet-sdk-browser": "3.8.1",
     "@stacks/transactions": "7.2.0",
-    "monaco-editor": "0.54.0",
+    "monaco-editor": "0.52.0",
     "monaco-editor-textmate": "4.0.0",
     "monaco-textmate": "3.0.1",
     "onigasm": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@hirosystems/clarinet-sdk-browser": "3.8.1",
     "@stacks/transactions": "7.2.0",
-    "monaco-editor": "0.52.0",
+    "monaco-editor": "0.54.0",
     "monaco-editor-textmate": "4.0.0",
     "monaco-textmate": "3.0.1",
     "onigasm": "2.2.5",

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -1,5 +1,10 @@
+self.MonacoEnvironment = {
+  getWorkerUrl: function (_moduleId, _label) {
+    return "https://esm.sh/monaco-editor@0.52.0/esm/vs/editor/editor.worker?worker";
+  },
+};
+
 import { decodeAndDecompress } from "./base64.js";
-import { initMonacoEditor } from "./editor.js";
 import { initClarinetSDK } from "./simnet.js";
 
 let initialSearchString = window.location.search;
@@ -13,6 +18,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   window.history.replaceState(null, "", url.toString());
 
   initClarinetSDK(initialContract, params);
+  const { initMonacoEditor } = await import("./editor.js");
   initMonacoEditor(initialContract);
 });
 

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -1,6 +1,4 @@
 import { decodeAndDecompress } from "./base64.js";
-import { initClarinetSDK } from "./simnet.js";
-import { initMonacoEditor } from "./editor.js";
 
 let initialSearchString = window.location.search;
 
@@ -12,8 +10,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   url.searchParams.delete("snippet");
   window.history.replaceState(null, "", url.toString());
 
-  initClarinetSDK(initialContract, params);
-  initMonacoEditor(initialContract);
+  import("./simnet.js").then(({ initClarinetSDK }) => {
+    initClarinetSDK(initialContract, params);
+  });
+  import("./editor.js").then(({ initMonacoEditor }) => {
+    initMonacoEditor(initialContract);
+  });
 });
 
 // get initial contract from URL or local storage

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -1,11 +1,6 @@
-self.MonacoEnvironment = {
-  getWorkerUrl: function (_moduleId, _label) {
-    return "https://esm.sh/monaco-editor@0.52.0/esm/vs/editor/editor.worker?worker";
-  },
-};
-
 import { decodeAndDecompress } from "./base64.js";
 import { initClarinetSDK } from "./simnet.js";
+import { initMonacoEditor } from "./editor.js";
 
 let initialSearchString = window.location.search;
 
@@ -18,7 +13,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   window.history.replaceState(null, "", url.toString());
 
   initClarinetSDK(initialContract, params);
-  const { initMonacoEditor } = await import("./editor.js");
   initMonacoEditor(initialContract);
 });
 

--- a/src/scripts/editor.js
+++ b/src/scripts/editor.js
@@ -18,7 +18,6 @@ export async function initMonacoEditor(initialContract) {
     folding: true,
   });
 
-  // init monaco editor
   const editor = monaco.editor.create(window.editor, {
     value: initialContract,
     language: "clarity",

--- a/src/scripts/editor.js
+++ b/src/scripts/editor.js
@@ -1,12 +1,11 @@
 import { compressAndEncode } from "./base64.js";
 import { deployContract, setDeployedStatus } from "./simnet.js";
+import { monaco } from "./monaco/monaco.js";
 
 /**
  * @param {string} initialContract
  */
-export async function initMonacoEditor(initialContract) {
-  const { monaco } = await import("./monaco/monaco.js");
-
+export function initMonacoEditor(initialContract) {
   const smallScreenOptions = Object.freeze({
     lineNumbers: "off",
     glyphMargin: false,

--- a/src/scripts/monaco/monaco.js
+++ b/src/scripts/monaco/monaco.js
@@ -1,3 +1,16 @@
+self.MonacoEnvironment = {
+  getWorkerUrl: function (_moduleId, _label) {
+    const workerUrl =
+      "https://cdn.jsdelivr.net/npm/monaco-editor@0.54.0/esm/vs/editor/editor.worker.js";
+
+    const blob = new Blob([`import '${workerUrl}';`], {
+      type: "application/javascript",
+    });
+
+    return URL.createObjectURL(blob);
+  },
+};
+
 import * as monaco from "monaco-editor";
 import { Registry } from "monaco-textmate";
 import { wireTmGrammars } from "monaco-editor-textmate";

--- a/src/scripts/monaco/monaco.js
+++ b/src/scripts/monaco/monaco.js
@@ -1,7 +1,7 @@
 self.MonacoEnvironment = {
   getWorkerUrl: function (_moduleId, _label) {
     const workerUrl =
-      "https://cdn.jsdelivr.net/npm/monaco-editor@0.54.0/esm/vs/editor/editor.worker.js";
+      "https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/esm/vs/editor/editor.worker.js";
 
     const blob = new Blob([`import '${workerUrl}';`], {
       type: "application/javascript",

--- a/src/scripts/monaco/monaco.js
+++ b/src/scripts/monaco/monaco.js
@@ -1,6 +1,3 @@
-/* @ts-ignore */
-import editorWorker from "https://esm.sh/monaco-editor@0.54.0/esm/vs/editor/editor.worker?worker";
-
 import * as monaco from "monaco-editor";
 import { Registry } from "monaco-textmate";
 import { wireTmGrammars } from "monaco-editor-textmate";
@@ -9,12 +6,6 @@ import { loadWASM } from "onigasm";
 import { claritySyntax } from "./clarity-syntax.js";
 import { configLanguage } from "./clarity-language.js";
 import theme from "./theme.js";
-
-self.MonacoEnvironment = {
-  getWorker(_, _label) {
-    return new editorWorker();
-  },
-};
 
 monaco.editor.defineTheme("vs-dark", theme);
 configLanguage(monaco);


### PR DESCRIPTION
- remove gtm
- esm.sh was struggling with the monaco-editor web worker for some reason - it was messing with platform detection, using ctrl instead of cmd for shortcuts on macos. JSDelivr was a bit harder to setup, but it works now. Also, had to downgrade to 0.52.0