### PR TITLE
chore: use @stacks/clarinet-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Clarity Playground
 
 Run Clarity code in the browser with the
-[Clarinet SDK](https://www.npmjs.com/package/@hirosystems/clarinet-sdk-browser).
+[Clarinet SDK](https://www.npmjs.com/package/@stacks/clarinet-sdk-browser).
 
 The playground gives access to the [Simnet](https://docs.hiro.so/clarinet/networks) in the browser.
 It's possible to:

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
   <script type="importmap">
       {
         "imports": {
-          "@hirosystems/clarinet-sdk-browser": "https://esm.sh/@hirosystems/clarinet-sdk-browser@3.8.1",
+          "@stacks/clarinet-sdk-browser": "https://esm.sh/@stacks/clarinet-sdk-browser@3.9.1",
           "@stacks/transactions": "https://esm.sh/@stacks/transactions@7.2.0",
           "monaco-editor": "https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/+esm",
           "monaco-editor-textmate": "https://esm.sh/monaco-editor-textmate@4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "GPL-3.0",
       "devDependencies": {
-        "@hirosystems/clarinet-sdk-browser": "3.8.1",
+        "@stacks/clarinet-sdk-browser": "3.9.1",
         "@stacks/transactions": "7.2.0",
         "monaco-editor": "0.52.0",
         "monaco-editor-textmate": "4.0.0",
@@ -17,24 +17,6 @@
         "onigasm": "2.2.5",
         "serve": "14.2.5"
       }
-    },
-    "node_modules/@hirosystems/clarinet-sdk-browser": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-browser/-/clarinet-sdk-browser-3.8.1.tgz",
-      "integrity": "sha512-RC/Ow6hND6JUIXoO/AYwizn12dCUATQq4uC2xZKxxEr39v7ViEaSnvvT95fvrN+14Zbe3tiRNP7mz52ZdpHIhA==",
-      "dev": true,
-      "license": "GPL-3.0",
-      "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm-browser": "3.8.1",
-        "@stacks/transactions": "^7.0.6"
-      }
-    },
-    "node_modules/@hirosystems/clarinet-sdk-wasm-browser": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk-wasm-browser/-/clarinet-sdk-wasm-browser-3.8.1.tgz",
-      "integrity": "sha512-8CimzpFq/Ai/VH0uYsxLrJtWwg7xJ1Yk+1uB3KJCMyK9LL3IaTw4qOV6VBgONm65QK225iH3ItXOz6heT8dQ+w==",
-      "dev": true,
-      "license": "GPL-3.0"
     },
     "node_modules/@noble/hashes": {
       "version": "1.1.5",
@@ -61,6 +43,24 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@stacks/clarinet-sdk-browser": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-browser/-/clarinet-sdk-browser-3.9.1.tgz",
+      "integrity": "sha512-1cfKIQDMr39lNu5odNmjUiAxvESk2OjU5FKjOwIoYhgKB4KEGTSFsFfO/v4fF3ka8gzcnZ3RirJo6XKCMmYpkQ==",
+      "dev": true,
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@stacks/clarinet-sdk-wasm-browser": "3.9.1",
+        "@stacks/transactions": "^7.0.6"
+      }
+    },
+    "node_modules/@stacks/clarinet-sdk-wasm-browser": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm-browser/-/clarinet-sdk-wasm-browser-3.9.1.tgz",
+      "integrity": "sha512-H0JiOtoj10CCSAC4EAlvO1rAZoxuVWtDoeWMMpHBdT4WGpHL6by+9xPULgh9X1FqhfXnEUG1D8YJbdgOg7E6eg==",
+      "dev": true,
+      "license": "GPL-3.0"
     },
     "node_modules/@stacks/common": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "GPL-3.0",
   "devDependencies": {
-    "@hirosystems/clarinet-sdk-browser": "3.8.1",
+    "@stacks/clarinet-sdk-browser": "3.9.1",
     "@stacks/transactions": "7.2.0",
     "monaco-editor": "0.52.0",
     "monaco-editor-textmate": "4.0.0",

--- a/src/scripts/simnet-worker.js
+++ b/src/scripts/simnet-worker.js
@@ -14,7 +14,7 @@ let deployed = false;
 // @ts-ignore
 globalThis.window = globalThis;
 
-/** @import { Simnet } from "@hirosystems/clarinet-sdk-browser" */
+/** @import { Simnet } from "@stacks/clarinet-sdk-browser" */
 /** @import { InitOptions } from "./simnet" */
 
 /** @type {Simnet | null} */
@@ -76,7 +76,7 @@ function postClarityResult(value, classes) {
 export async function initClarinetSDK(options) {
   const { initSimnet, SDK } = await import(
     // @ts-ignore
-    "https://esm.sh/@hirosystems/clarinet-sdk-browser@latest"
+    "https://esm.sh/@stacks/clarinet-sdk-browser@latest"
   );
 
   // init simnet


### PR DESCRIPTION
Use `@stacks/clarinet-sdk-browser` instead of `@hirosystems/`